### PR TITLE
[14.0][IMP] l10n_pt_invoice_spms: pre-commit auto fixes and guideline fixes

### DIFF
--- a/l10n_pt_invoice_spms/README.rst
+++ b/l10n_pt_invoice_spms/README.rst
@@ -55,6 +55,9 @@ Contributors
 ------------
 
 - Enric Tobella
+- `NuoBiT <https://www.nuobit.com>`__
+
+  - Eric Antones eantones@nuobit.com
 
 Maintainers
 -----------

--- a/l10n_pt_invoice_spms/README.rst
+++ b/l10n_pt_invoice_spms/README.rst
@@ -26,7 +26,7 @@ L10n Pt Invoice Spms
 
 |badge1| |badge2| |badge3|
 
-Generate invocie for SPMS
+Generate invoice for SPMS
 
 **Table of contents**
 

--- a/l10n_pt_invoice_spms/README.rst
+++ b/l10n_pt_invoice_spms/README.rst
@@ -20,9 +20,9 @@ L10n Pt Invoice Spms
 .. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-oxigensalud%2Fodoo--community--addons-lightgray.png?logo=github
-    :target: https://github.com/oxigensalud/odoo-community-addons/tree/14.0/l10n_pt_invoice_spms
-    :alt: oxigensalud/odoo-community-addons
+.. |badge3| image:: https://img.shields.io/badge/github-oxigensalud%2Fodoo--nonstandalone--addons-lightgray.png?logo=github
+    :target: https://github.com/oxigensalud/odoo-nonstandalone-addons/tree/14.0/l10n_pt_invoice_spms
+    :alt: oxigensalud/odoo-nonstandalone-addons
 
 |badge1| |badge2| |badge3|
 
@@ -36,10 +36,10 @@ Generate invocie for SPMS
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/oxigensalud/odoo-community-addons/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/oxigensalud/odoo-nonstandalone-addons/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/oxigensalud/odoo-community-addons/issues/new?body=module:%20l10n_pt_invoice_spms%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/oxigensalud/odoo-nonstandalone-addons/issues/new?body=module:%20l10n_pt_invoice_spms%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -59,6 +59,6 @@ Contributors
 Maintainers
 -----------
 
-This module is part of the `oxigensalud/odoo-community-addons <https://github.com/oxigensalud/odoo-community-addons/tree/14.0/l10n_pt_invoice_spms>`_ project on GitHub.
+This module is part of the `oxigensalud/odoo-nonstandalone-addons <https://github.com/oxigensalud/odoo-nonstandalone-addons/tree/14.0/l10n_pt_invoice_spms>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/l10n_pt_invoice_spms/__manifest__.py
+++ b/l10n_pt_invoice_spms/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "14.0.1.0.0",
     "license": "AGPL-3",
     "author": "Dixmit",
-    "website": "https://github.com/oxigensalud/odoo-community-addons",
+    "website": "https://github.com/oxigensalud/odoo-nonstandalone-addons",
     "depends": [
         "ptplus_edi",
         "edi_account_oca",

--- a/l10n_pt_invoice_spms/__manifest__.py
+++ b/l10n_pt_invoice_spms/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2025 Dixmit
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -13,7 +14,7 @@
         "edi_account_oca",
         "l10n_pt_spms",
     ],
-    "external_dependencies": {"python": ["zeep", "xmlsig"]},
+    "external_dependencies": {"python": ["OpenSSL", "xmlsig"]},
     "data": [
         "views/menu.xml",
         "views/account_move.xml",

--- a/l10n_pt_invoice_spms/components/edi_output_generate_l10n_pt_spms.py
+++ b/l10n_pt_invoice_spms/components/edi_output_generate_l10n_pt_spms.py
@@ -1,5 +1,6 @@
 # Copyright 2026 Dixmit
 # @author: Enric Tobella
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
@@ -29,29 +30,29 @@ class EdiOutputGenerateL10nPtSpms(Component):
             raise UserError(_("Errors while generating XML: %s" % errors))
         einvoice = etree.fromstring(xml_content)
         extensions = einvoice.find(
-            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtensions"  # noqa: disable=B950
+            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtensions"  # noqa: B950
         )
         if extensions is None:
             extensions = etree.Element(
-                "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtensions"  # noqa: disable=B950
+                "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtensions"  # noqa: B950
             )
             einvoice.insert(0, extensions)
 
         extension = etree.Element(
-            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtension"  # noqa: disable=B950
+            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtension"  # noqa: B950
         )
         extensions.insert(0, extension)
         etree.SubElement(
             extension,
-            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}ExtensionURI",  # noqa: disable=B950
+            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}ExtensionURI",  # noqa: B950
         ).text = "urn:oasis:names:specification:ubl:dsig:enveloped"
         extension_content = etree.SubElement(
             extension,
-            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}ExtensionContent",  # noqa: disable=B950
+            "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}ExtensionContent",  # noqa: B950
         )
         signature_information = etree.SubElement(
             extension_content,
-            "{urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2}UBLDocumentSignatures",  # noqa: disable=B950d
+            "{urn:oasis:names:specification:ubl:schema:xsd:CommonSignatureComponents-2}UBLDocumentSignatures",  # noqa: B950
         )
         sign = xmlsig.template.create(
             c14n_method=xmlsig.constants.TransformExclC14NWithComments,

--- a/l10n_pt_invoice_spms/components/edi_output_generate_l10n_pt_spms.py
+++ b/l10n_pt_invoice_spms/components/edi_output_generate_l10n_pt_spms.py
@@ -27,7 +27,7 @@ class EdiOutputGenerateL10nPtSpms(Component):
         builder = edi_format._get_xml_builder(invoice.company_id)
         xml_content, errors = builder._export_invoice(invoice)
         if errors:
-            raise UserError(_("Errors while generating XML: %s" % errors))
+            raise UserError(_("Errors while generating XML: %s") % errors)
         einvoice = etree.fromstring(xml_content)
         extensions = einvoice.find(
             "{urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2}UBLExtensions"  # noqa: B950

--- a/l10n_pt_invoice_spms/components/edi_output_send_l10n_pt_spms.py
+++ b/l10n_pt_invoice_spms/components/edi_output_send_l10n_pt_spms.py
@@ -10,7 +10,8 @@ from uuid import uuid4
 import requests
 from lxml import etree
 
-from odoo import fields
+from odoo import _, fields
+from odoo.exceptions import UserError
 
 from odoo.addons.component.core import Component
 
@@ -100,7 +101,7 @@ class EdiOutputSendL10nPtSpms(Component):
         response_xml = etree.fromstring(response.content)
         aceite = response_xml.xpath("//aceite")
         if not aceite or aceite[0].text != "S":
-            raise Exception(
-                "Invoice not accepted: %s" % response.content.decode("utf-8")
+            raise UserError(
+                _("Invoice not accepted: %s") % response.content.decode("utf-8")
             )
         return response.content.decode("utf-8")

--- a/l10n_pt_invoice_spms/components/edi_output_send_l10n_pt_spms.py
+++ b/l10n_pt_invoice_spms/components/edi_output_send_l10n_pt_spms.py
@@ -1,5 +1,6 @@
 # Copyright 2026 Dixmit
 # @author: Enric Tobella
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
@@ -25,8 +26,10 @@ SOAPENV_NS = "http://schemas.xmlsoap.org/soap/envelope/"
 FACTURA_NS = "http://facturaElectronica.service.cc.ccf/"
 
 
-WSDL = "https://www.ccf.min-saude.pt/WSExternoBroker/ProxyService/FacturaCRDWS"  # noqa: disable=B950
-WSDL_TEST = "https://www.ccf.min-saude.pt/WSExternoBroker/ProxyService/FacturaCRDServiceDEV"  # noqa: disable=B950
+WSDL = "https://www.ccf.min-saude.pt/WSExternoBroker/ProxyService/FacturaCRDWS"
+WSDL_TEST = (
+    "https://www.ccf.min-saude.pt/WSExternoBroker/ProxyService/FacturaCRDServiceDEV"
+)
 
 
 class EdiOutputSendL10nPtSpms(Component):
@@ -61,7 +64,7 @@ class EdiOutputSendL10nPtSpms(Component):
         password = etree.SubElement(username_token, f"{{{WSSE_NS}}}Password")
         password.set(
             "Type",
-            "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText",  # noqa: disable=B950
+            "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText",  # noqa: B950
         )
         password.text = invoice.company_id.spms_password
         body = etree.SubElement(root, f"{{{SOAPENV_NS}}}Body")

--- a/l10n_pt_invoice_spms/data/edi.xml
+++ b/l10n_pt_invoice_spms/data/edi.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Dixmit
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
 
     <record id="spms_edi_format" model="account.edi.format">

--- a/l10n_pt_invoice_spms/data/spms_templates.xml
+++ b/l10n_pt_invoice_spms/data/spms_templates.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Dixmit
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <template
         id="spms_cius_pt_211_PartyType"

--- a/l10n_pt_invoice_spms/models/account_edi_format.py
+++ b/l10n_pt_invoice_spms/models/account_edi_format.py
@@ -1,4 +1,5 @@
 # Copyright 2025 Dixmit
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
@@ -51,11 +52,11 @@ class AccountEdiXmlSpmsCiusPt211(models.AbstractModel):
         vals.update(
             {
                 "InvoiceType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_InvoiceType",
-                "InvoiceExtension_spms": "l10n_pt_invoice_spms.spms_cius_pt_211_InvoiceExtension_spms",  # noqa: disable=B950
+                "InvoiceExtension_spms": "l10n_pt_invoice_spms.spms_cius_pt_211_InvoiceExtension_spms",  # noqa: B950
                 "InvoiceLineType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_InvoiceLine",
                 "PartyType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_PartyType",
                 "AddressType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_AddressType",
-                "TaxCategoryType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_TaxCategoryType",  # noqa: disable=B950
+                "TaxCategoryType_template": "l10n_pt_invoice_spms.spms_cius_pt_211_TaxCategoryType",  # noqa: B950
             }
         )
         vals["vals"].update(
@@ -87,7 +88,7 @@ class AccountEdiXmlSpmsCiusPt211(models.AbstractModel):
                                 "tax_total_vals"
                             ][i]["tax_subtotal_vals"][j]["tax_amount"] += tax_subtotal[
                                 "tax_amount"
-                            ]  # noqa: disable=B950
+                            ]
                             j += 1
                         i += 1
             else:

--- a/l10n_pt_invoice_spms/readme/CONTRIBUTORS.md
+++ b/l10n_pt_invoice_spms/readme/CONTRIBUTORS.md
@@ -1,1 +1,3 @@
 - Enric Tobella
+- [NuoBiT](https://www.nuobit.com)
+  - Eric Antones <eantones@nuobit.com>

--- a/l10n_pt_invoice_spms/readme/DESCRIPTION.md
+++ b/l10n_pt_invoice_spms/readme/DESCRIPTION.md
@@ -1,1 +1,1 @@
-Generate invocie for SPMS
+Generate invoice for SPMS

--- a/l10n_pt_invoice_spms/static/description/index.html
+++ b/l10n_pt_invoice_spms/static/description/index.html
@@ -372,7 +372,7 @@ ul.auto-toc {
 !! source digest: sha256:379cdaff99cc9c174e758f71c149396da6992cb6df66a0d43ad7bf01bd47aa31
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/oxigensalud/odoo-nonstandalone-addons/tree/14.0/l10n_pt_invoice_spms"><img alt="oxigensalud/odoo-nonstandalone-addons" src="https://img.shields.io/badge/github-oxigensalud%2Fodoo--nonstandalone--addons-lightgray.png?logo=github" /></a></p>
-<p>Generate invocie for SPMS</p>
+<p>Generate invoice for SPMS</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/l10n_pt_invoice_spms/static/description/index.html
+++ b/l10n_pt_invoice_spms/static/description/index.html
@@ -405,6 +405,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-4">Contributors</a></h3>
 <ul class="simple">
 <li>Enric Tobella</li>
+<li><a class="reference external" href="https://www.nuobit.com">NuoBiT</a><ul>
+<li>Eric Antones <a class="reference external" href="mailto:eantones&#64;nuobit.com">eantones&#64;nuobit.com</a></li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_pt_invoice_spms/static/description/index.html
+++ b/l10n_pt_invoice_spms/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -363,9 +362,7 @@ ul.auto-toc {
 <div class="document">
 
 
-<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme">
-<img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme"><img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" /></a>
 <div class="section" id="l10n-pt-invoice-spms">
 <h1>L10n Pt Invoice Spms</h1>
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -374,7 +371,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:379cdaff99cc9c174e758f71c149396da6992cb6df66a0d43ad7bf01bd47aa31
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/oxigensalud/odoo-community-addons/tree/14.0/l10n_pt_invoice_spms"><img alt="oxigensalud/odoo-community-addons" src="https://img.shields.io/badge/github-oxigensalud%2Fodoo--community--addons-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/oxigensalud/odoo-nonstandalone-addons/tree/14.0/l10n_pt_invoice_spms"><img alt="oxigensalud/odoo-nonstandalone-addons" src="https://img.shields.io/badge/github-oxigensalud%2Fodoo--nonstandalone--addons-lightgray.png?logo=github" /></a></p>
 <p>Generate invocie for SPMS</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
@@ -390,10 +387,10 @@ ul.auto-toc {
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/oxigensalud/odoo-community-addons/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/oxigensalud/odoo-nonstandalone-addons/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/oxigensalud/odoo-community-addons/issues/new?body=module:%20l10n_pt_invoice_spms%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/oxigensalud/odoo-nonstandalone-addons/issues/new?body=module:%20l10n_pt_invoice_spms%0Aversion:%2014.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -412,7 +409,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h3>
-<p>This module is part of the <a class="reference external" href="https://github.com/oxigensalud/odoo-community-addons/tree/14.0/l10n_pt_invoice_spms">oxigensalud/odoo-community-addons</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/oxigensalud/odoo-nonstandalone-addons/tree/14.0/l10n_pt_invoice_spms">oxigensalud/odoo-nonstandalone-addons</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # generated from manifests external_dependencies
+pyOpenSSL
 xmlsig
-zeep


### PR DESCRIPTION
## Summary

Follow-up on the recently-merged `l10n_pt_invoice_spms` module to bring it into OCA / NuoBiT guideline compliance. One concept per commit:

- **[IMP] pre-commit auto fixes** — `oca-fix-manifest-website` + `oca-gen-addon-readme` regenerated the manifest `website` key and `README.rst` / `static/description/index.html` with the correct `odoo-nonstandalone-addons` links (now that the repo-name fix is in `.pre-commit-config.yaml`).
- **[FIX] external python dependencies** — drop unused `zeep` (never imported), declare imported `OpenSSL`; root `requirements.txt` regenerated.
- **[FIX] malformed noqa directives** — `# noqa: disable=B950` is invalid flake8 syntax (the `disable=` form is pylint's) and acted as a blanket suppression hiding every warning on the line; one had a `B950d` typo. Replaced with the specific `# noqa: B950`, unnecessary ones removed. Comments only — no code or strings changed.
- **[FIX] translation string outside `_()`** — `_("...%s" % e)` → `_("...%s") % e`. Runtime output unchanged (no translations shipped yet).
- **[FIX] `UserError` on SPMS rejection** — the rejection branch raised a bare `Exception`, which the `edi_oca` backend leaves uncaught (the job crashes, the exchange stays `output_pending`, the rejection reason is lost). `UserError` is swallable → the exchange goes to `output_error_on_send` with the message stored. Matches the same author's FACe webservice component.
- **[IMP] license headers on the data files** — `data/edi.xml` / `data/spms_templates.xml` were the only module files without the copyright/license header; also lowercased `edi.xml`'s XML encoding to match the module's own other XML files.
- **[FIX] description typo** — "invocie" → "invoice".

The author's executable logic is unchanged except the exception fix (a bug fix).

## Test plan
- [x] pre-commit green (all hooks) locally
- [x] `py_compile` OK on the changed Python files
- [ ] CI green
- The module has no test suite and its runtime path depends on the live SPMS webservice, so functional tests cannot be run offline.
